### PR TITLE
Fix session error when user no longer exists after database reset

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,14 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+    return nil unless session[:user_id]
+    
+    @current_user ||= begin
+      user = User.find_by(id: session[:user_id])
+      # Clear stale session if user no longer exists
+      session[:user_id] = nil unless user
+      user
+    end
   end
   helper_method :current_user
 


### PR DESCRIPTION
## Summary
- Fix session error when user no longer exists after database reset
- Update current_user method to handle stale sessions gracefully
- Automatically clear invalid sessions to prevent errors

## Changes
- Updated `ApplicationController#current_user` to use `find_by` instead of `find`
- Added automatic session cleanup when user doesn't exist
- Maintains proper authentication flow for both valid and invalid sessions

## Test plan
- [x] All existing tests pass
- [x] Users with stale sessions can access login page without errors
- [x] Valid user sessions continue to work normally
- [x] Stale sessions are automatically cleared

🤖 Generated with [Claude Code](https://claude.ai/code)