### PR TITLE
Add comprehensive development workflow and quality checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Pre-commit hook that runs security and lint checks
+# To install: git config core.hooksPath .githooks
+#
+
+set -e
+
+echo "🔍 Running pre-commit checks..."
+
+# Check if we're in a Rails project
+if [ ! -f "Gemfile" ]; then
+  echo "❌ Not a Rails project, skipping checks"
+  exit 0
+fi
+
+# Run RuboCop for code style (auto-fix mode)
+echo "📏 Running RuboCop..."
+if ! bundle exec rubocop -a --display-cop-names; then
+  echo "❌ RuboCop failed. Some issues couldn't be auto-fixed."
+  echo "💡 Run 'bundle exec rubocop' to see remaining issues."
+  exit 1
+fi
+
+# Run Brakeman for security
+echo "🛡️  Running Brakeman security scan..."
+if ! bundle exec brakeman --no-pager --quiet; then
+  echo "❌ Security vulnerabilities found! Please fix before committing."
+  echo "💡 Run 'bin/brakeman --no-pager' for details."
+  exit 1
+fi
+
+# Run a quick smoke test (not full suite to keep commits fast)
+echo "🧪 Running quick tests..."
+if ! bundle exec ruby -Itest test/models/user_test.rb; then
+  echo "❌ Quick tests failed! Run full test suite with 'bin/rails test'"
+  exit 1
+fi
+
+echo "✅ All pre-commit checks passed!"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "shopify.ruby-lsp",
+    "bradlc.vscode-tailwindcss",
+    "ms-vscode.vscode-json",
+    "rebornix.ruby",
+    "koichisasada.vscode-rdbg",
+    "castwide.solargraph"
+  ],
+  "unwantedRecommendations": [
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "ruby.format": "rubocop",
+  "ruby.lint": {
+    "rubocop": true,
+    "brakeman": true
+  },
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.rubocop": "explicit"
+  },
+  "files.associations": {
+    "*.html.erb": "erb",
+    "*.js.erb": "javascript"
+  },
+  "tailwindCSS.includeLanguages": {
+    "erb": "html",
+    "ruby": "html"
+  },
+  "tailwindCSS.emmetCompletions": true,
+  "emmet.includeLanguages": {
+    "erb": "html"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,22 @@
-- always run the tests before you generate the PR
+## Development Workflow & Quality Checks
+
+### Before Making Any PR
+1. **Run full CI checks locally**: `bin/dev-check` or `npm run ci`
+2. **Always run tests**: `bin/rails test` 
+3. **Check code style**: `bundle exec rubocop -a` (auto-fix)
+4. **Security scan**: `bundle exec brakeman --no-pager`
+
+### Available Commands
+- `bin/dev-check` - Run all CI checks locally (recommended before push)
+- `npm run check` - Same as above (alternative interface)
+- `npm run lint` - RuboCop style check
+- `npm run lint:fix` - Auto-fix RuboCop issues
+- `npm run security` - Brakeman security scan
+- `npm run test` - Run test suite
+
+### Git Hooks (Optional)
+To automatically run checks on every commit:
+```bash
+git config core.hooksPath .githooks
+```
+This runs security + lint + quick tests before each commit.

--- a/bin/dev-check
+++ b/bin/dev-check
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Development check script - runs the same checks as CI locally
+puts "🚀 Running development checks (same as CI)..."
+
+def run_command(name, command, description)
+  puts "\n#{name} #{description}..."
+  result = system(command)
+  if result
+    puts "✅ #{name} passed"
+  else
+    puts "❌ #{name} failed"
+    exit(1)
+  end
+end
+
+# Security scan
+run_command("🛡️  Brakeman", "bundle exec brakeman --no-pager", "security scan")
+
+# JavaScript security scan  
+run_command("🔍 Importmap", "bin/importmap audit", "JavaScript security audit")
+
+# Lint check
+run_command("📏 RuboCop", "bundle exec rubocop -f progress", "code style check")
+
+# Full test suite
+run_command("🧪 Tests", "bin/rails test", "full test suite")
+
+puts "\n🎉 All checks passed! Ready to commit and push."
+puts "💡 These are the same checks that run in GitHub Actions CI."

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "visible_wins",
+  "version": "1.0.0",
+  "description": "Team schedule tracking application",
+  "scripts": {
+    "check": "bin/dev-check",
+    "lint": "bundle exec rubocop",
+    "lint:fix": "bundle exec rubocop -a",
+    "security": "bundle exec brakeman --no-pager",
+    "security:js": "bin/importmap audit",
+    "test": "bin/rails test",
+    "test:system": "bin/rails test:system",
+    "ci": "npm run security && npm run security:js && npm run lint && npm run test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/taylor01/visible_wins.git"
+  },
+  "keywords": [
+    "rails",
+    "schedule",
+    "team",
+    "management"
+  ],
+  "author": "IT Team",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
Adds multiple integration points for running GitHub Actions CI checks locally before making PRs, preventing failed builds and ensuring code quality.

## Key Features Added

### 🔧 **Pre-commit Hook** (`.githooks/pre-commit`)
- Automatically runs on every commit
- RuboCop auto-fix + Brakeman security scan + quick tests
- Install: `git config core.hooksPath .githooks`
- Prevents bad commits from reaching the repository

### 🚀 **Developer Check Script** (`bin/dev-check`)
- Runs **identical checks to GitHub Actions CI**
- One command to verify PR readiness
- Clear pass/fail feedback with helpful error messages

### 📦 **NPM Scripts** (`package.json`)
- `npm run check` - Full CI check suite
- `npm run lint`, `npm run security`, `npm run test` - Individual checks
- `npm run ci` - Complete CI simulation
- Familiar interface for frontend developers

### 🛠️ **VS Code Integration** (`.vscode/`)
- Recommended Ruby/Rails extensions
- Auto-format on save with RuboCop
- Real-time linting and security feedback
- Tailwind CSS support for ERB templates

### 📖 **Updated Documentation** (`CLAUDE.md`)
- Clear pre-PR checklist
- Available commands reference
- Git hooks setup instructions

## Developer Workflow

**Before any PR:**
```bash
# Option 1: Run full CI checks locally
bin/dev-check

# Option 2: Using npm interface  
npm run ci

# Option 3: Individual checks
npm run lint:fix  # Auto-fix style issues
npm run security  # Security scan
npm run test      # Run tests
```

**Automatic protection:**
```bash
# Install git hooks for automatic checks
git config core.hooksPath .githooks
```

## Test Plan
- [x] All existing tests continue to pass
- [x] `bin/dev-check` runs successfully and matches CI checks
- [x] Pre-commit hook functions correctly
- [x] NPM scripts work as expected
- [x] VS Code settings are valid

This addresses the CI failures we've been seeing by giving developers the same checks locally that run in GitHub Actions (`scan_ruby`, `scan_js`, `lint`, `test`).

🤖 Generated with [Claude Code](https://claude.ai/code)